### PR TITLE
[FIX] notification detection - Unknown observed: Missing actions

### DIFF
--- a/app/src/main/kotlin/com/faltenreich/camaps/service/camaps/notification/CamApsFxNotificationMapper.kt
+++ b/app/src/main/kotlin/com/faltenreich/camaps/service/camaps/notification/CamApsFxNotificationMapper.kt
@@ -59,12 +59,14 @@ class CamApsFxNotificationMapper {
         val memberProperties = from::class.memberProperties
 
         val methodNameProperty = memberProperties
-            .firstOrNull { it.name == "mMethodName" }
+            .firstOrNull { it.name == "mMethodName" || it.name == "methodName" }
             ?: return null
         methodNameProperty.isAccessible = true
         val methodName = methodNameProperty.getter.call(from) as? String ?: return null
 
-        val valueProperty = memberProperties.firstOrNull { it.name == "mValue" } ?: return null
+        val valueProperty = memberProperties
+            .firstOrNull { it.name == "mValue" || it.name == "value" }
+            ?: return null
         valueProperty.isAccessible = true
         val value = valueProperty.getter.call(from)
 


### PR DESCRIPTION
With the current main branch, when running the application it doesn't seem to be able to detect the readings, just getting the error
`Unknown observed: Missing actions`

<img width="1080" height="2460" alt="Image" src="https://github.com/user-attachments/assets/6d59491d-6b3a-4a92-98ab-300f9f4f52b5" />

This PR seems to resolve it